### PR TITLE
Fix pymodbus import to match latest version of package

### DIFF
--- a/modbus.py
+++ b/modbus.py
@@ -1,11 +1,14 @@
 import struct
 import time
 
-import pymodbus.client.sync
 import pymodbus.register_read_message as rrm
 
+try:
+    from pymodbus.client import ModbusTcpClient
+except ImportError:
+    from pymodbus.client.sync import ModbusTcpClient
 
-class CrevisModbus (pymodbus.client.sync.ModbusTcpClient):
+class CrevisModbus (ModbusTcpClient):
     def read_sr (self, reg, maxlen=1):
         r = None
         tryCount = 5


### PR DESCRIPTION
The functionality in pymodbus.client.sync has been moved and is now accessible directly through pymodbus.client.

Pydmodbus change: https://github.com/riptideio/pymodbus/commit/2906725e332335d7e703a96f3e472d3e012f1438